### PR TITLE
fix: remove remaining alternatives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+max_line_length = 127
 
 [*.{yml,yaml}]
 indent_style = space

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           directory: .
           snakefile: workflow/Snakefile
-          args: "--lint --configfile config/config_github.yaml"
+          args: "--lint --configfile config/config_github.yml"
   # Testing:
   #   runs-on: ubuntu-latest
   #   needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           directory: .
           snakefile: workflow/Snakefile
-          args: "--lint --configfile config/example_github.yaml"
+          args: "--lint --configfile config/config_github.yaml"
   # Testing:
   #   runs-on: ubuntu-latest
   #   needs:

--- a/config/config_github.yml
+++ b/config/config_github.yml
@@ -2,8 +2,10 @@ reference:
   genome: /github/workspace/resources/reference/hg38.chrom.sizes
   fasta: /github/workspace/resources/reference/hg38_test.fa
 datasets: 
-  variants_regions: /github/workspace/config/test_datasets_variants_regions_github.tsv
-  regions_only: /github/workspace/config/test_datasets_regions_only_github.tsv
+  variants_regions:
+    - /github/workspace/config/test_datasets_variants_regions_github.tsv
+  regions_only:
+    - /github/workspace/config/test_datasets_regions_only_github.tsv
 
 oligo_length: 150
 

--- a/config/config_github.yml
+++ b/config/config_github.yml
@@ -13,6 +13,8 @@ tiling:
   remove_edge_variants: true
   min_overlap: 50
   strategies:
+    centering:
+      max: 250
     two_tiles:
       max: 250 # 170 wil be used because of 2*150 -2 *50 -2*15
       include_variant_edge: true

--- a/config/config_github.yml
+++ b/config/config_github.yml
@@ -1,7 +1,8 @@
+---
 reference:
   genome: /github/workspace/resources/reference/hg38.chrom.sizes
   fasta: /github/workspace/resources/reference/hg38_test.fa
-datasets: 
+datasets:
   variants_regions:
     - /github/workspace/config/test_datasets_variants_regions_github.tsv
   regions_only:

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -1,0 +1,7 @@
+---
+configfile: config/example_config.yaml
+software-deployment-method: conda
+default-resources:
+  slurm_partition: debug
+  mem: 5G
+  runtime: 60

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -5,14 +5,18 @@ SCRIPTS_DIR = "../scripts"
 
 
 def getScript(name):
-    return workflow.source_path("%s/%s" % (SCRIPTS_DIR, name))
+    # Construct the path to the scripts directory
+    scripts_dir = os.path.abspath(os.path.join(workflow.basedir, 'scripts'))
+    return os.path.join(scripts_dir, name)
 
 
 REFERENCE_DIR = "../../reference"
 
 
 def getReference(name):
-    return workflow.source_path("%s/%s" % (REFERENCE_DIR, name))
+    # Construct the path to the reference directory
+    reference_dir = os.path.abspath(os.path.join(workflow.basedir, '../reference'))
+    return os.path.join(reference_dir, name)
 
 
 from snakemake.utils import validate

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -6,7 +6,7 @@ SCRIPTS_DIR = "../scripts"
 
 def getScript(name):
     # Construct the path to the scripts directory
-    scripts_dir = os.path.abspath(os.path.join(workflow.basedir, 'scripts'))
+    scripts_dir = os.path.abspath(os.path.join(workflow.basedir, "scripts"))
     return os.path.join(scripts_dir, name)
 
 
@@ -15,7 +15,7 @@ REFERENCE_DIR = "../../reference"
 
 def getReference(name):
     # Construct the path to the reference directory
-    reference_dir = os.path.abspath(os.path.join(workflow.basedir, '../reference'))
+    reference_dir = os.path.abspath(os.path.join(workflow.basedir, "../reference"))
     return os.path.join(reference_dir, name)
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -5,18 +5,14 @@ SCRIPTS_DIR = "../scripts"
 
 
 def getScript(name):
-    # Construct the path to the scripts directory
-    scripts_dir = os.path.abspath(os.path.join(workflow.basedir, "scripts"))
-    return os.path.join(scripts_dir, name)
+    return workflow.source_path("%s/%s" % (SCRIPTS_DIR, name))
 
 
 REFERENCE_DIR = "../../reference"
 
 
 def getReference(name):
-    # Construct the path to the reference directory
-    reference_dir = os.path.abspath(os.path.join(workflow.basedir, "../reference"))
-    return os.path.join(reference_dir, name)
+    return workflow.source_path("%s/%s" % (REFERENCE_DIR, name))
 
 
 from snakemake.utils import validate


### PR DESCRIPTION
Removed alternatives of associated references which get filtered out 
Additionally, a profile was created and the way the paths to the scripts and reference data are prepared was changed because of segmentation faults during debugging